### PR TITLE
fix: use POST for Azure login in DRF template

### DIFF
--- a/src/hope_payment_gateway/web/templates/rest_framework/base.html
+++ b/src/hope_payment_gateway/web/templates/rest_framework/base.html
@@ -10,7 +10,10 @@
     {{ block.super }}
     {% if not user.is_authenticated %}
         <li>
-            <a class="button" href="{% ad_backend %}">Login with Azure</a>
+            <form method="post" action="{% ad_backend %}">
+                {% csrf_token %}
+                <button class="button" type="submit">Login with Azure</button>
+            </form>
         </li>
     {% endif %}
 {% endblock userlinks %}


### PR DESCRIPTION
social-auth-app-django 6.0.0 requires POST on the auth view. Replace the GET link with a form containing csrf_token.